### PR TITLE
Fix Open File and Add Open Background Spectrum

### DIFF
--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useDispatch } from "react-redux";
-import { setError, storeProcessedData, storeParams } from "../redux/actions";
+import { setError, storeProcessedData, storeParams, storeBackgroundData } from "../redux/actions";
 
 // style
 import "../style/components/Open.css";
@@ -9,6 +9,7 @@ import "../style/components/Open.css";
 //   https://dev.to/pankod/how-to-import-csv-file-with-react-4pj2
 export const Open = () => {
   const [data, setData] = useState();
+  const [filename, setFilename] = useState();
   const dispatch = useDispatch();
   const filereader = new FileReader();
   const [sucess, toggleSucess] = useState(false);
@@ -18,6 +19,8 @@ export const Open = () => {
       filereader.onload = function (e) {
         setData(e.target.result);
       };
+      setFilename(event.target.files[0].name);
+      console.log(filename);
       filereader.readAsText(event.target.files[0]);
     }
   };
@@ -67,7 +70,12 @@ export const Open = () => {
       rawData = rawData.substring(index + 1);
     }
 
-    dispatch(storeProcessedData({ x: xData, y: yData }));
+    if (filename.includes("background")){
+      dispatch(storeBackgroundData({ x: xData, y: yData}));
+    } else {
+      dispatch(storeProcessedData({ x: xData, y: yData }));
+    }
+
     dispatch(setError({ active: false }));
     toggleSucess(true);
   };

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -34,7 +34,7 @@ export const Open = () => {
       if (line.charAt(0) !== "#") {
         let comma = line.indexOf(",");
         let x = line.substring(0, comma);
-        let y = line.substring(comma);
+        let y = line.substring(comma + 1);
 
         xData.push(Number(x));
         yData.push(Number(y));

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -21,7 +21,6 @@ export const Open = () => {
         setFilename(event.target.files[0].name);
       };
       filereader.readAsText(event.target.files[0]);
-      console.log(filename);
     }
   };
 
@@ -69,6 +68,8 @@ export const Open = () => {
       }
       rawData = rawData.substring(index + 1);
     }
+    console.log(filename);
+
 
     if (filename.includes("background")){
       dispatch(storeBackgroundData({ x: xData, y: yData}));
@@ -87,7 +88,7 @@ export const Open = () => {
           Select a File
           <input type="file" name="file" onChange={changeHandler} />
         </label>
-        <h1>{sucess && "Upload Sucessful!"}</h1>
+        <h2>{sucess && "Upload Sucessful!"}</h2>
         <button className="button" onClick={handleSubmission}>
           Upload
         </button>

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -18,10 +18,10 @@ export const Open = () => {
     if (event.target.files[0]) {
       filereader.onload = function (e) {
         setData(e.target.result);
+        setFilename(event.target.files[0].name);
       };
-      setFilename(event.target.files[0].name);
-      console.log(filename);
       filereader.readAsText(event.target.files[0]);
+      console.log(filename);
     }
   };
 

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -40,36 +40,36 @@ export const Open = () => {
 
         xData.push(Number(x));
         yData.push(Number(y));
-      } else {
-        const parameters = [];
-        while (line.indexOf(":") > 0) {
-          let paramStart = line.indexOf(":") + 2; // The Additional 2 accounts for the colon inself and the following space
-          line = line.substring(paramStart);
-          let paramEnd = line.indexOf(" ");
-          let param = line.substring(0, paramEnd);
-          line = line.substring(paramEnd + 1);
-          parameters.push(param);
-        }
+      // } else {
+      //   const parameters = [];
+      //   while (line.indexOf(":") > 0) {
+      //     let paramStart = line.indexOf(":") + 2; // The Additional 2 accounts for the colon inself and the following space
+      //     line = line.substring(paramStart);
+      //     let paramEnd = line.indexOf(" ");
+      //     let param = line.substring(0, paramEnd);
+      //     line = line.substring(paramEnd + 1);
+      //     parameters.push(param);
+      //   }
 
-        for (let i = 0; i < parameters.length; i++){
-          console.log(parameters[i]);
-        }
+      //   for (let i = 0; i < parameters.length; i++){
+      //     console.log(parameters[i]);
+      //   }
 
-        dispatch(
-          storeParams({
-            minWave: parameters[0],
-            maxWave: parameters[1],
-            molecule: parameters[2],
-            pressure: parameters[3],
-            resolution: parameters[4],
-            numScan: parameters[5],
-            zeroFill: parameters[6],
-            source: parameters[7],
-            beamsplitter: parameters[8],
-            cellWindow: parameters[9],
-            detector: parameters[10],
-          })
-        );
+      //   dispatch(
+      //     storeParams({
+      //       minWave: parameters[0],
+      //       maxWave: parameters[1],
+      //       molecule: parameters[2],
+      //       pressure: parameters[3],
+      //       resolution: parameters[4],
+      //       numScan: parameters[5],
+      //       zeroFill: parameters[6],
+      //       source: parameters[7],
+      //       beamsplitter: parameters[8],
+      //       cellWindow: parameters[9],
+      //       detector: parameters[10],
+      //     })
+      //   );
       }
       rawData = rawData.substring(index + 1);
     }

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useDispatch } from "react-redux";
-import { setError, storeProcessedData, storeParams, storeBackgroundData } from "../redux/actions";
+import { setError, storeProcessedData, storeBackgroundData } from "../redux/actions";
 
 // style
 import "../style/components/Open.css";

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -50,6 +50,11 @@ export const Open = () => {
           line = line.substring(paramEnd + 1);
           parameters.push(param);
         }
+
+        for (let i = 0; i < parameters.length; i++){
+          console.log(parameters[i]);
+        }
+
         dispatch(
           storeParams({
             minWave: parameters[0],
@@ -68,8 +73,6 @@ export const Open = () => {
       }
       rawData = rawData.substring(index + 1);
     }
-    console.log(filename);
-
 
     if (filename.includes("background")){
       dispatch(storeBackgroundData({ x: xData, y: yData}));

--- a/src/style/components/Popup.css
+++ b/src/style/components/Popup.css
@@ -1,4 +1,11 @@
 /* ---------- popup ---------- */
+.popup h1 {
+  font-family: "Montserrat";
+  text-align: center;
+  padding: 20px 0;
+  text-decoration: underline;
+}
+
 .popup h2 {
   font-family: "Montserrat";
   text-align: center;


### PR DESCRIPTION
Users can open a file that will be loaded into the Background Spectrum if "background" is in the filename. All other files are loaded into the Processed Spectrum.

Also, when you opened a file, it set the FTIR parameters to the parameters from the file that was loaded. This was causing the FTIR to become unusable as it threw several errors, one of which was only resolved by refreshing the page. I ended up removing this part of the Open functionality and this resolved that issue.