### PR TITLE
Fix Menu Bar Popup Hight

### DIFF
--- a/src/style/components/Popup.css
+++ b/src/style/components/Popup.css
@@ -1,4 +1,8 @@
 /* ---------- popup ---------- */
+.popup .MuiDialog-paper {
+  height: 80% !important;
+}
+
 .popup h1 {
   font-family: "Montserrat";
   text-align: center;
@@ -25,9 +29,4 @@
 
 .popup li {
   padding: 1.5% 0;
-}
-
-.MuiDialog-paper {
-  width: 100%;
-  height: 80%;
 }


### PR DESCRIPTION
Closes #197 
One stylesheet had the `MuiDialog-paper` height set to `80%`, another has it set to `auto.` I specified that the 80% height should only apply to elements in the `popup `class. Now the menu bar popups are their correct hight and the tooltips adjust to fit their contents.