### PR TITLE
cancel scans works for mcc, can disable Landing Page popup with flag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,9 @@ export default function App() {
   const [gitHubPopover, setGutHubPopover] = useState(false);
   const [infoPopover, setInfoPopover] = useState(false);
 
-  const [welcomeOpen, setWelcomeOpen] = useState(true);
+  const [welcomeOpen, setWelcomeOpen] = useState(
+    localStorage.getItem("checked") === "true" ? false : true
+  );
 
   const handleChange = (panel) => (newExpanded) => {
     setExpanded(newExpanded ? panel : false);
@@ -77,12 +79,19 @@ export default function App() {
 
   const handleWelcomeClose = () => {
     setWelcomeOpen(false);
-  }
+  };
 
   return (
     <div>
-      <Dialog className="welcome popup" open={welcomeOpen} onClose={handleWelcomeClose}>
-        <CloseButton id="customized-dialog-title" onClose={handleWelcomeClose}/>
+      <Dialog
+        className="welcome popup"
+        open={welcomeOpen}
+        onClose={handleWelcomeClose}
+      >
+        <CloseButton
+          id="customized-dialog-title"
+          onClose={handleWelcomeClose}
+        />
         <LandingPage />
       </Dialog>
 
@@ -140,7 +149,10 @@ export default function App() {
                             );
                           } else if (submenu.link) {
                             return (
-                              <p key={submenu.link} className={"dropdown-items"}>
+                              <p
+                                key={submenu.link}
+                                className={"dropdown-items"}
+                              >
                                 <Link
                                   to={submenu.link ?? "#"}
                                   onClick={submenu.action}
@@ -151,7 +163,12 @@ export default function App() {
                             );
                           } else {
                             return (
-                              <ul key={submenu.label} className={"dropdown-items"}>{submenu.component}</ul>
+                              <ul
+                                key={submenu.label}
+                                className={"dropdown-items"}
+                              >
+                                {submenu.component}
+                              </ul>
                             );
                           }
                         })}
@@ -224,7 +241,11 @@ export default function App() {
                         </p>
                       );
                     } else {
-                      return <ul key={submenu.label} className={"dropdown-items"}>{submenu.component}</ul>;
+                      return (
+                        <ul key={submenu.label} className={"dropdown-items"}>
+                          {submenu.component}
+                        </ul>
+                      );
                     }
                   })}
                 </AccordionDetails>

--- a/src/components/CancelScan.jsx
+++ b/src/components/CancelScan.jsx
@@ -1,6 +1,9 @@
 // components
 import { sleepID } from "./Fetch";
 
+// functions
+import { stopCornerCube } from "../functions/animation";
+
 // redux
 import { useDispatch, useSelector } from "react-redux";
 
@@ -19,6 +22,7 @@ export default function CancelScan() {
 
   const handleClick = () => {
     clearTimeout(sleepID);
+    stopCornerCube();
     dispatch(setProgress(false));
     dispatch(setSpinner(false));
     dispatch(setTimer(0));

--- a/src/functions/animation.js
+++ b/src/functions/animation.js
@@ -113,6 +113,42 @@ export function animateCornerCube(cycles, time) {
 }
 
 /**
+ * Function that stops the current animation of the moveable corner cube and reset its location
+ */
+export function stopCornerCube() {
+  const mcc = document.getElementById("movable-corner-cube");
+  const rayTop = document.getElementById("ray-top");
+  const rayMiddle = document.getElementById("ray-middle");
+  const rayBottom = document.getElementById("ray-bottom");
+  const laser = document.getElementById("rect6675");
+
+  mcc.getAnimations().forEach((animation) => animation.cancel());
+  laser.getAnimations().forEach((animation) => animation.cancel());
+  rayTop.getAnimations().forEach((animation) => animation.cancel());
+  rayMiddle.getAnimations().forEach((animation) => animation.cancel());
+  rayBottom.getAnimations().forEach((animation) => animation.cancel());
+
+  mcc.style.transform = "translate(0px, 0px)";
+
+  laser.setAttribute(
+    "d",
+    "M1406.494 991.284v10h651.235v209.254H344.494v10H2067.73V991.284z"
+  );
+
+  rayTop.setAttribute(
+    "d",
+    "m2026.826 953.417 93.734 94.391h-673.324l-95.49-94.391z"
+  );
+
+  rayMiddle.style.transform = "translate(0px, 0px)";
+
+  rayBottom.setAttribute(
+    "d",
+    "m2120.56 1164.195-93.733 94.356H582.917l-89.932-94.356z"
+  );
+}
+
+/**
  * Function that changes the visibility of the beamsplitter based on user set parameters
  *
  * @param {string} store - The current value selected by the user.

--- a/src/routes/LandingPage.jsx
+++ b/src/routes/LandingPage.jsx
@@ -34,11 +34,6 @@ export default function LandingPage() {
       <br />
       <p>Please use the navigation bar above to explore the application!</p>
       <br />
-      <p>
-        <b>
-          NOTE: Please use a Chromium based browser for the best experience!
-        </b>
-      </p>
     </div>
   );
 }

--- a/src/routes/LandingPage.jsx
+++ b/src/routes/LandingPage.jsx
@@ -1,4 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
+
+// components
+import { Switch } from "@mui/material";
 
 // style
 import "../style/routes/LandingPage.css";
@@ -7,10 +10,22 @@ import "../style/routes/LandingPage.css";
  * React Router "Landing Page" for the project. Currently used as a splash page
  *
  * Information used to create this "Landing Page": https://stackoverflow.com/questions/33228589/react-router-adding-in-a-landing-page/72267552#72267552
- *
- * @returns
  */
 export default function LandingPage() {
+  const [checked, setChecked] = useState(
+    localStorage.getItem("checked") === "true" ? true : false
+  );
+
+  const handleChange = (event) => {
+    if (event.target.checked) {
+      localStorage.setItem("checked", "true");
+      setChecked(true);
+    } else {
+      localStorage.setItem("checked", "false");
+      setChecked(false);
+    }
+  };
+
   return (
     <div id="landing-page">
       <h1>
@@ -24,6 +39,7 @@ export default function LandingPage() {
         <span className="indigo">I</span>
         <span className="purple">S</span>!
       </h1>
+
       <h2>
         <u className="red">F</u>ourier <u className="orange">T</u>ransform{" "}
         <u className="yellow">I</u>nfra<u className="green">R</u>ed
@@ -31,9 +47,15 @@ export default function LandingPage() {
         <u className="blue">S</u>cientific <u className="indigo">I</u>nstrument{" "}
         <u className="purple">S</u>imulator
       </h2>
+
       <br />
+
       <p>Please use the navigation bar above to explore the application!</p>
+
       <br />
+
+      <Switch checked={checked} onChange={handleChange} />
+      <p>Hide this popup when opened?</p>
     </div>
   );
 }


### PR DESCRIPTION
close #287 
`Cancel Scan` now stops the moveable corner cube animation. From my testing this works in both FireFox and Chrome

close #291 
Checkbox saves data to local browser storage to stop Landing Page popup. Can be found in Chrome devtools:
- `Application` --> `Storage` --> `Local Storage`