### PR TITLE
Scan Times and Adustments

### DIFF
--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -1,8 +1,5 @@
 import React, { useState } from "react";
 
-// functions
-import { animateCornerCube } from "../functions/animation";
-
 // mui
 import { Box, CircularProgress } from "@mui/material";
 import Typography from "@mui/material/Typography";
@@ -29,7 +26,7 @@ export default function Spinner(props) {
     if (props.timer) {
       const timer_interval = setInterval(() => {
         // If the scans are complete, turn off spinner
-        if (delay === 100) {
+        if (delay >= 100) {
           dispatch(setProgress(false));
         }
 
@@ -42,12 +39,7 @@ export default function Spinner(props) {
       dispatch(setTimer(delay));
 
       // Keeps track of the number of scans done
-      if (scansDone < props.scans && delay >= (100 / props.scans) * scansDone) {
-        // Triggers the animation on even numbered scans
-        if (scansDone % 2 === 0) {
-          animateCornerCube(props.scans / 2, props.opd);
-          console.log(scansDone);
-        }
+      if (scansDone < props.scans && delay >= props.oneScan * scansDone) {
         setScansDone(scansDone + 1);
       }
 
@@ -62,7 +54,7 @@ export default function Spinner(props) {
     scansDone,
     setScansDone,
     props.scans,
-    props.opd,
+    props.oneScan,
   ]);
 
   return (

--- a/src/dictionaries/constants.js
+++ b/src/dictionaries/constants.js
@@ -41,13 +41,13 @@ export const BAD_ID = [
 
 // OPD values used to calculate a scans length
 export const OPD = {
-  1: { value: 1, distance: 0.5 },
-  0.5: { value: 2, distance: 1 },
-  0.25: { value: 4, distance: 2 },
-  0.125: { value: 8, distance: 4 },
-  0.0625: { value: 16, distance: 8 },
-  // 0.03125: { value: 32, distance: 16 },
-  // 0.015625: { value: 64, distance: 32 },
+  1: {      value: 1,   distance: 0.5,  time: 0.703125 },
+  0.5: {    value: 2,   distance: 1,    time: 1.40625 },
+  0.25: {   value: 4,   distance: 2,    time: 2.8125 },
+  0.125: {  value: 8,   distance: 4,    time: 5.625 },
+  0.0625: { value: 16,  distance: 8,    time: 11.25 },
+  // 0.03125: { value: 32, distance: 16, time: 22.5 },
+  // 0.015625: { value: 64, distance: 32, time: 45 },
 };
 
 // backend values associated with user parameters/inputs

--- a/src/routes/InstrumentWindow.jsx
+++ b/src/routes/InstrumentWindow.jsx
@@ -73,7 +73,7 @@ export default function InstrumentWindow() {
     setDrawerOpen(!drawerOpen);
   };
 
-  const delay = OPD[resolution].value * scan * 1000; // 1000 is to convert to milliseconds
+  const delay = OPD[resolution].time * scan * 1000; // 1000 is to convert to milliseconds
 
   // find group id when SVG is clicked
   const handleClick = (event) => {
@@ -131,8 +131,9 @@ export default function InstrumentWindow() {
               timer={delay}
               scans={scan}
               size={100}
-              opd={OPD[resolution].value}
+              oneScan={OPD[resolution].time}
             />
+            {animateCornerCube(scan / 2, OPD[resolution].time * 2)}
           </>
         )}
       </div>


### PR DESCRIPTION
Resolves #265 
There was a notable amount of reworking done for this. Now that we have discrete times for scans I was able to separate the animation and the spinner; I kept the trigger for them the same but the animation is no longer reliant on the spinner. I was also able to simplify some of the math in `Spinner.jsx`.