### PR TITLE
update sample compartment description, start checks for parameters when generating transmission and absorbance spectra

### DIFF
--- a/src/components/AbsorbancePlotly.jsx
+++ b/src/components/AbsorbancePlotly.jsx
@@ -20,27 +20,24 @@ import "../style/components/Absorbance.css";
  * A component that uses Plotly.js to graph absorbance spectrum data
  */
 export const AbsorbancePlotly = forwardRef((props, ref) => {
-  const { absorbanceData } = useSelector((store) => store.absorbanceData);
-  const { backgroundData } = useSelector((store) => store.backgroundData);
-  const { sampleData, sampleWaveMin, sampleWaveMax } = useSelector(
-    (store) => store.sampleData
+  const { backgroundData, backgroundParameters } = useSelector(
+    (store) => store.backgroundData
   );
-  
+  const { sampleData, sampleWaveMin, sampleWaveMax, sampleParameters } =
+    useSelector((store) => store.sampleData);
+
   const dispatch = useDispatch();
 
-  // if the correct data exists, calculate the absorbance data
-  if (sampleData && backgroundData && !absorbanceData) {
+  const absorbanceData = generateAbsorbance(
+    backgroundData,
+    sampleData,
+    backgroundParameters,
+    sampleParameters
+  );
 
-    dispatch(
-      setAbsorbanceData([
-        generateAbsorbance(backgroundData, sampleData),
-        sampleWaveMin,
-        sampleWaveMax,
-      ])
-    );
-  }
+  dispatch(setAbsorbanceData([absorbanceData, sampleWaveMin, sampleWaveMax]));
 
-  if (absorbanceData) {
+  if (absorbanceData.error === false) {
     return (
       <div className="absorbance">
         {/* Graph */}
@@ -82,6 +79,16 @@ export const AbsorbancePlotly = forwardRef((props, ref) => {
           useResizeHandler={true}
         />
         {/* End Graph */}
+      </div>
+    );
+  } else if (absorbanceData.error === true) {
+    return (
+      <div>
+        <p>
+          The parameters used to generate Background and Sample spectra do not
+          match. To view the Absorbance spectrum, please generate both with the
+          same parameters.
+        </p>
       </div>
     );
   } else {

--- a/src/components/AbsorbancePlotly.jsx
+++ b/src/components/AbsorbancePlotly.jsx
@@ -13,8 +13,8 @@ import { setAbsorbanceData } from "../redux/absorbanceDataSlice";
 import { generateAbsorbance } from "../dictionaries/dataFunctions";
 
 // style
-import "../style/components/Plotly.css";
 import "../style/components/Absorbance.css";
+import "../style/components/Plotly.css";
 
 /**
  * A component that uses Plotly.js to graph absorbance spectrum data

--- a/src/components/CloseButton.jsx
+++ b/src/components/CloseButton.jsx
@@ -1,7 +1,6 @@
 // components
+import { DialogTitle, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 
 /**
  * A component used in MUI Dialog and Drawer to close those overlays

--- a/src/components/Fetch.jsx
+++ b/src/components/Fetch.jsx
@@ -12,12 +12,15 @@ import { useDispatch, useSelector } from "react-redux";
 
 // redux slices
 import { setAbsorbanceData } from "../redux/absorbanceDataSlice";
-import { setBackgroundData } from "../redux/backgroundDataSlice";
+import {
+  setBackgroundData,
+  setBackgroundParameters,
+} from "../redux/backgroundDataSlice";
 import { setError } from "../redux/errorSlice";
 import { setLectureBottle } from "../redux/lectureBottleSlice";
 import { setPeaksData } from "../redux/peaksDataSlice";
 import { setProgress } from "../redux/progressSlice";
-import { setSampleData } from "../redux/sampleDataSlice";
+import { setSampleData, setSampleParameters } from "../redux/sampleDataSlice";
 import { setTimer } from "../redux/timerSlice";
 
 // router
@@ -225,6 +228,24 @@ export default function Fetch({
               sleepID = setTimeout(() => {
                 dispatch(setProgress(false, false, false));
                 dispatch(setSampleData([data, waveMin, waveMax]));
+                dispatch(
+                  setSampleParameters(
+                    JSON.stringify({
+                      beamsplitter: beamsplitter,
+                      detector: detector,
+                      medium: medium,
+                      molecule: molecule,
+                      pressure: pressure,
+                      resolution: resolution,
+                      scan: scan,
+                      source: source,
+                      waveMax: waveMax,
+                      waveMin: waveMin,
+                      window: window,
+                      zeroFill: zeroFill,
+                    })
+                  )
+                );
               }, delay);
               break;
             case "background":
@@ -241,6 +262,24 @@ export default function Fetch({
               sleepID = setTimeout(() => {
                 dispatch(setProgress(false, false, false));
                 dispatch(setBackgroundData([data, waveMin, waveMax]));
+                dispatch(
+                  setBackgroundParameters(
+                    JSON.stringify({
+                      beamsplitter: beamsplitter,
+                      detector: detector,
+                      medium: medium,
+                      molecule: molecule,
+                      pressure: pressure,
+                      resolution: resolution,
+                      scan: scan,
+                      source: source,
+                      waveMax: waveMax,
+                      waveMin: waveMin,
+                      window: window,
+                      zeroFill: zeroFill,
+                    })
+                  )
+                );
               }, delay);
               break;
             case "find_peaks":

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
 
+// components
+import CloseButton from "./CloseButton.jsx";
+
+// mui
+import { Dialog } from "@mui/material";
+
 // redux
 import { useDispatch } from "react-redux";
 
@@ -24,14 +30,7 @@ import {
   setWindow,
   setZeroFill,
 } from "../redux/parameterSlice";
-
 import { setAbsorbanceData } from "../redux/absorbanceDataSlice";
-
-// components
-import CloseButton from "./CloseButton.jsx";
-
-// mui
-import { Dialog } from "@mui/material";
 
 // style
 import "../style/components/Open.css";

--- a/src/components/Open.jsx
+++ b/src/components/Open.jsx
@@ -5,8 +5,11 @@ import { useDispatch } from "react-redux";
 
 // redux slices
 import { setError } from "../redux/errorSlice";
-import { setBackgroundData } from "../redux/backgroundDataSlice";
-import { setSampleData } from "../redux/sampleDataSlice";
+import {
+  setBackgroundData,
+  setBackgroundParameters,
+} from "../redux/backgroundDataSlice";
+import { setSampleData, setSampleParameters } from "../redux/sampleDataSlice";
 import {
   setBeamsplitter,
   setDetector,
@@ -145,6 +148,24 @@ export const Open = () => {
             parseFloat(parameters[1]),
           ])
         );
+        dispatch(
+          setBackgroundParameters(
+            JSON.stringify({
+              beamsplitter: parameters[8],
+              detector: parameters[10],
+              medium: parameters[11],
+              molecule: parameters[2],
+              pressure: parseFloat(parameters[3]),
+              resolution: parseFloat(parameters[4]),
+              scan: parseFloat(parameters[5]),
+              source: parseFloat(parameters[7]),
+              waveMax: parseFloat(parameters[1]),
+              waveMin: parseFloat(parameters[0]),
+              window: parameters[9],
+              zeroFill: parseFloat(parameters[6]),
+            })
+          )
+        );
       } else if (specType.includes("Sample")) {
         dispatch(
           setSampleData([
@@ -152,6 +173,24 @@ export const Open = () => {
             parseFloat(parameters[0]),
             parseFloat(parameters[1]),
           ])
+        );
+        dispatch(
+          setSampleParameters(
+            JSON.stringify({
+              beamsplitter: parameters[8],
+              detector: parameters[10],
+              medium: parameters[11],
+              molecule: parameters[2],
+              pressure: parseFloat(parameters[3]),
+              resolution: parseFloat(parameters[4]),
+              scan: parseFloat(parameters[5]),
+              source: parseFloat(parameters[7]),
+              waveMax: parseFloat(parameters[1]),
+              waveMin: parseFloat(parameters[0]),
+              window: parameters[9],
+              zeroFill: parseFloat(parameters[6]),
+            })
+          )
         );
       }
 

--- a/src/components/TransmittancePlotly.jsx
+++ b/src/components/TransmittancePlotly.jsx
@@ -16,15 +16,24 @@ import "../style/components/Plotly.css";
  * A component that uses Plotly.js to graph transmittance spectrum data
  */
 export const TransmittancePlotly = forwardRef((props, ref) => {
-  const { backgroundData } = useSelector((store) => store.backgroundData);
-  const { sampleData } = useSelector((store) => store.sampleData);
+  const { backgroundData, backgroundParameters } = useSelector(
+    (store) => store.backgroundData
+  );
+  const { sampleData, sampleParameters } = useSelector(
+    (store) => store.sampleData
+  );
   const { waveMaxSaved, waveMinSaved } = useSelector(
     (store) => store.parameter
   );
 
-  const transData = generateTransmittance(backgroundData, sampleData);
+  const transmittanceData = generateTransmittance(
+    backgroundData,
+    sampleData,
+    backgroundParameters,
+    sampleParameters
+  );
 
-  if (sampleData) {
+  if (transmittanceData.error === false) {
     return (
       <>
         {
@@ -33,8 +42,8 @@ export const TransmittancePlotly = forwardRef((props, ref) => {
             className="plotly"
             data={[
               {
-                x: transData.x,
-                y: transData.y,
+                x: transmittanceData.x,
+                y: transmittanceData.y,
                 type: "scatter",
                 marker: { color: "#f50057" },
               },
@@ -67,6 +76,16 @@ export const TransmittancePlotly = forwardRef((props, ref) => {
           />
         }
       </>
+    );
+  } else if (transmittanceData.error === true) {
+    return (
+      <div>
+        <p>
+          The parameters used to generate Background and Sample spectra do not
+          match. To view the Transmittance spectrum, please generate both with
+          the same parameters.
+        </p>
+      </div>
     );
   } else {
     return <div></div>;

--- a/src/components/inputs/Beamsplitter.js
+++ b/src/components/inputs/Beamsplitter.js
@@ -5,10 +5,7 @@ import { SwitchStyle } from "./SwitchStyle";
 import { PARAMETER_LABEL } from "../../dictionaries/constants";
 
 // mui
-import FormControl from "@mui/material/FormControl";
-import FormLabel from "@mui/material/FormLabel";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/CellWindow.js
+++ b/src/components/inputs/CellWindow.js
@@ -5,10 +5,7 @@ import { SwitchStyle } from "./SwitchStyle";
 import { PARAMETER_LABEL } from "../../dictionaries/constants";
 
 // mui
-import FormControl from "@mui/material/FormControl";
-import FormLabel from "@mui/material/FormLabel";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/Detector.js
+++ b/src/components/inputs/Detector.js
@@ -5,10 +5,7 @@ import { SwitchStyle } from "./SwitchStyle";
 import { PARAMETER_LABEL } from "../../dictionaries/constants";
 
 // mui
-import FormControl from "@mui/material/FormControl";
-import FormLabel from "@mui/material/FormLabel";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/Medium.js
+++ b/src/components/inputs/Medium.js
@@ -5,10 +5,7 @@ import { SwitchStyle } from "./SwitchStyle";
 import { PARAMETER_LABEL } from "../../dictionaries/constants";
 
 // mui
-import FormControl from "@mui/material/FormControl";
-import FormLabel from "@mui/material/FormLabel";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/Molecule.js
+++ b/src/components/inputs/Molecule.js
@@ -1,8 +1,5 @@
 // mui
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/Pressure.js
+++ b/src/components/inputs/Pressure.js
@@ -1,6 +1,5 @@
 // mui
-import InputAdornment from "@mui/material/InputAdornment";
-import TextField from "@mui/material/TextField";
+import { InputAdornment, TextField } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";
@@ -8,6 +7,7 @@ import { useDispatch } from "react-redux";
 // redux store
 import { setPressure } from "../../redux/parameterSlice";
 
+// style
 import "../../style/components/NumberInputs.css"
 
 /**

--- a/src/components/inputs/Resolution.js
+++ b/src/components/inputs/Resolution.js
@@ -1,8 +1,5 @@
 // mui
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/Scan.js
+++ b/src/components/inputs/Scan.js
@@ -1,9 +1,6 @@
 // mui
-import Grid from "@mui/material/Grid";
-import Input from "@mui/material/Input";
+import { Grid, Input, Slider, Typography } from "@mui/material";
 import ShowChartIcon from "@mui/icons-material/ShowChart";
-import Slider from "@mui/material/Slider";
-import Typography from "@mui/material/Typography";
 
 // redux
 import { useDispatch } from "react-redux";
@@ -11,6 +8,7 @@ import { useDispatch } from "react-redux";
 // redux slice
 import { setScan } from "../../redux/parameterSlice";
 
+// style
 import "../../style/components/NumberInputs.css"
 
 /**

--- a/src/components/inputs/Source.js
+++ b/src/components/inputs/Source.js
@@ -5,10 +5,7 @@ import { SwitchStyle } from "./SwitchStyle";
 import { PARAMETER_LABEL } from "../../dictionaries/constants";
 
 // mui
-import FormControl from "@mui/material/FormControl";
-import FormLabel from "@mui/material/FormLabel";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/components/inputs/SwitchStyle.js
+++ b/src/components/inputs/SwitchStyle.js
@@ -1,6 +1,5 @@
-import { styled } from "@mui/material";
+import { styled, Switch } from "@mui/material";
 import { pink, blue } from "@mui/material/colors";
-import { Switch } from "@mui/material";
 
 /**
  * A component that contains custom style elements for a MUI Switch

--- a/src/components/inputs/Wavenumber.js
+++ b/src/components/inputs/Wavenumber.js
@@ -1,8 +1,5 @@
 // mui
-import Grid from "@mui/material/Grid";
-import Input from "@mui/material/Input";
-import Slider from "@mui/material/Slider";
-import Typography from "@mui/material/Typography";
+import { Grid, Input, Slider, Typography } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";
@@ -10,6 +7,7 @@ import { useDispatch } from "react-redux";
 // redux slice
 import { setWaveMin, setWaveMax } from "../../redux/parameterSlice";
 
+// style
 import "../../style/components/NumberInputs.css"
 
 /**

--- a/src/components/inputs/ZeroFill.js
+++ b/src/components/inputs/ZeroFill.js
@@ -1,8 +1,5 @@
 // mui
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 
 // redux
 import { useDispatch } from "react-redux";

--- a/src/dictionaries/dataFunctions.js
+++ b/src/dictionaries/dataFunctions.js
@@ -1,41 +1,54 @@
-export function generateAbsorbance(backgroundData, sampleData) {
-  const newY = [sampleData.x.length];
+export function generateAbsorbance(backgroundData, sampleData, backgroundParameters,
+  sampleParameters) {
+  if (backgroundParameters === sampleParameters ? true : false) {
+    const newY = [sampleData.x.length];
 
-  for (let i = 0; i < sampleData.x.length; i++) {
-    newY[i] = -1 * Math.log(Math.abs(sampleData.y[i] / backgroundData.y[i]));
+    for (let i = 0; i < sampleData.x.length; i++) {
+      newY[i] = -1 * Math.log(Math.abs(sampleData.y[i] / backgroundData.y[i]));
 
-    if (newY[i] > 5) {
-      newY[i] = 5;
+      if (newY[i] > 5) {
+        newY[i] = 5;
+      }
+
+      if (newY[i] < -5) {
+        newY[i] = -5;
+      }
     }
 
-    if (newY[i] < -5) {
-      newY[i] = -5;
-    }
-  }
-
-  return {
+    return {
       x: sampleData.x,
       y: newY,
-  };
+      error: false,
+    };
+  }
+
+  return { error: true }
 }
 
-export function generateTransmittance(backgroundData, sampleData) {
-  const newY = [sampleData.x.length];
+export function generateTransmittance(backgroundData, sampleData, backgroundParameters,
+  sampleParameters) {
 
-  for (let i = 0; i < sampleData.x.length; i++) {
+  if (backgroundParameters === sampleParameters ? true : false) {
+    const newY = [sampleData.x.length];
+
+    for (let i = 0; i < sampleData.x.length; i++) {
       newY[i] = sampleData.y[i] / backgroundData.y[i];
 
       if (newY[i] > 2) {
-      newY[i] = 2;
+        newY[i] = 2;
       }
 
       if (newY[i] < -2) {
-      newY[i] = -2;
+        newY[i] = -2;
       }
+    }
+
+    return {
+      x: sampleData.x,
+      y: newY,
+      error: false,
+    };
   }
 
-  return {
-    x: sampleData.x,
-    y: newY
-  };
+  return { error: true }
 }

--- a/src/dictionaries/tooltips.js
+++ b/src/dictionaries/tooltips.js
@@ -545,10 +545,7 @@ export const tooltips = {
         <h1>Sample Compartment</h1>
 
         <p>
-          This compartment houses the sample cell within which the infrared
-          radiation is focused. In a typical FTIR spectrometer, this gas cell
-          can be switched out so that other sample types can be analyzed, such
-          as KBr pellets.
+          This compartment houses a 10 cm long sample cell within which the infrared radiation is focused. In a typical FTIR spectrometer, this gas cell can be switched out so that other sample types can be analyzed, such as KBr pellets.
         </p>
       </div>
     ),

--- a/src/redux/backgroundDataSlice.js
+++ b/src/redux/backgroundDataSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
+  backgroundParameters: null,
   backgroundData: null,
   backgroundWaveMin: null,
   backgroundWaveMax: null,
@@ -22,9 +23,13 @@ const backgroundDataSlice = createSlice({
       state.backgroundWaveMin = payload[1];
       state.backgroundWaveMax = payload[2];
     },
+
+    setBackgroundParameters: (state, { payload }) => {
+      state.backgroundParameters = payload
+    },
   },
 });
 
-export const { setBackgroundData } = backgroundDataSlice.actions;
+export const { setBackgroundData, setBackgroundParameters } = backgroundDataSlice.actions;
 
 export default backgroundDataSlice.reducer;

--- a/src/redux/sampleDataSlice.js
+++ b/src/redux/sampleDataSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
+  sampleParameters: null,
   sampleData: null,
   sampleWaveMin: null,
   sampleWaveMax: null,
@@ -22,9 +23,13 @@ const sampleDataSlice = createSlice({
       state.sampleWaveMin = payload[1];
       state.sampleWaveMax = payload[2];
     },
+
+    setSampleParameters: (state, { payload }) => {
+      state.sampleParameters = payload
+    },
   },
 });
 
-export const { setSampleData } = sampleDataSlice.actions;
+export const { setSampleData, setSampleParameters } = sampleDataSlice.actions;
 
 export default sampleDataSlice.reducer;

--- a/src/style/routes/SpectraWindow.css
+++ b/src/style/routes/SpectraWindow.css
@@ -1,4 +1,4 @@
-spectrum {
+#spectrum {
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
close #379 
Updated sample compartment text

Started work on #336 and #344 , both of these issues revolve around the Background and Sample spectra used to generate the Transmittance and Absorbance having different user selected parameters. With this merge, the Transmittance is finished. The Absorbance is working but the user has to open the Absorbance tab in the `Spectra` window to generate the spectrum. Find Peaks no longer can do this. This was changed because of infinite rendering loops.