### PR TITLE
add handling for empty inputs in find peaks, fix error with absorbanceWaveMin/Max, fix devtool key warning in find peaks

### DIFF
--- a/src/components/AbsorbancePlotly.jsx
+++ b/src/components/AbsorbancePlotly.jsx
@@ -25,25 +25,23 @@ export const AbsorbancePlotly = forwardRef((props, ref) => {
   );
   const { sampleData, sampleWaveMin, sampleWaveMax, sampleParameters } =
     useSelector((store) => store.sampleData);
-  const { absorbanceData } = useSelector(
-    (store) => store.absorbanceData
-    );
+  const { absorbanceData } = useSelector((store) => store.absorbanceData);
   const dispatch = useDispatch();
 
-    useEffect(() => {
-      if (!absorbanceData && (sampleData && backgroundData)) {
-        const absorbanceData = generateAbsorbance(
-          backgroundData,
-          sampleData,
-          backgroundParameters,
-          sampleParameters
-        );
-      
-        dispatch(setAbsorbanceData([absorbanceData, sampleWaveMin, sampleWaveMax]));
-      }
-    });
+  useEffect(() => {
+    if (!absorbanceData && sampleData && backgroundData) {
+      const absorbanceData = generateAbsorbance(
+        backgroundData,
+        sampleData,
+        backgroundParameters,
+        sampleParameters
+      );
 
-  
+      dispatch(
+        setAbsorbanceData([absorbanceData, sampleWaveMin, sampleWaveMax])
+      );
+    }
+  });
 
   if (absorbanceData && !absorbanceData.error) {
     return (

--- a/src/routes/FindPeaks.jsx
+++ b/src/routes/FindPeaks.jsx
@@ -288,16 +288,14 @@ export default function FindPeaks() {
               <div id="find-peaks-data-container">
                 <h1>Absorbance Peaks</h1>
                 <div id="find-peaks-results">
-                  <p id="find-peaks-text">
-                    {Object.keys(peaksData.peaks).map((key) => {
-                      return (
-                        <>
-                          {`Peak: ${key} Intensity: ${peaksData.peaks[key]}`}
-                          <br />
-                        </>
-                      );
-                    })}
-                  </p>
+                  {Object.keys(peaksData.peaks).map((key) => {
+                    return (
+                      <p id="find-peaks-text" key={key}>
+                        {`Peak: ${key} Intensity: ${peaksData.peaks[key]}`}
+                        <br />
+                      </p>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/src/routes/FindPeaks.jsx
+++ b/src/routes/FindPeaks.jsx
@@ -27,9 +27,10 @@ export default function FindPeaks() {
   const { backgroundData, backgroundParameters } = useSelector(
     (store) => store.backgroundData
   );
-  const { sampleWaveMin, sampleWaveMax, sampleData, sampleParameters } =
-    useSelector((store) => store.sampleData);
-  const { absorbanceData, absorbWaveMin, absorbWaveMax } = useSelector(
+  const { sampleData, sampleParameters } = useSelector(
+    (store) => store.sampleData
+  );
+  const { absorbanceData, absorbanceWaveMin, absorbanceWaveMax } = useSelector(
     (store) => store.absorbanceData
   );
   const { fetching } = useSelector((store) => store.progress);
@@ -37,10 +38,10 @@ export default function FindPeaks() {
 
   const [threshold, setThreshold] = useState(0.01);
   const [lowerBound, setLowerBound] = useState(
-    sampleWaveMin ? sampleWaveMin : ""
+    absorbanceWaveMin ? absorbanceWaveMin : ""
   );
   const [upperBound, setUpperBound] = useState(
-    sampleWaveMax ? sampleWaveMax : ""
+    absorbanceWaveMax ? absorbanceWaveMax : ""
   );
   const [dataPoints, setDataPoints] = useState();
   const [tooManyPoints, setTooManyPoints] = useState(true);
@@ -56,19 +57,19 @@ export default function FindPeaks() {
 
   const checkWaveNumRange = () => {
     if (!lowerBound) {
-      setLowerBound(sampleWaveMin);
+      setLowerBound(absorbanceWaveMin);
     }
 
     if (!upperBound) {
-      setUpperBound(sampleWaveMax);
+      setUpperBound(absorbanceWaveMax);
     }
 
-    if (lowerBound < sampleWaveMin) {
-      setLowerBound(sampleWaveMin);
+    if (lowerBound < absorbanceWaveMin) {
+      setLowerBound(absorbanceWaveMin);
     }
 
-    if (upperBound > sampleWaveMax) {
-      setUpperBound(sampleWaveMax);
+    if (upperBound > absorbanceWaveMax) {
+      setUpperBound(absorbanceWaveMax);
     }
 
     if (lowerBound > upperBound && upperBound) {
@@ -119,8 +120,6 @@ export default function FindPeaks() {
     dataPoints,
     lowerBound,
     upperBound,
-    sampleWaveMin,
-    sampleWaveMax,
   ]);
 
   if (absorbanceData) {
@@ -155,8 +154,8 @@ export default function FindPeaks() {
                     onBlur={checkWaveNumRange}
                     InputProps={{
                       inputProps: {
-                        min: absorbWaveMin,
-                        max: absorbWaveMax,
+                        min: absorbanceWaveMin,
+                        max: absorbanceWaveMax,
                       },
                     }}
                   />
@@ -167,11 +166,11 @@ export default function FindPeaks() {
                   <Slider
                     sx={{ minWidth: "150px" }}
                     value={[
-                      lowerBound ? lowerBound : sampleWaveMin,
-                      upperBound ? upperBound : sampleWaveMax,
+                      lowerBound ? lowerBound : absorbanceWaveMin,
+                      upperBound ? upperBound : absorbanceWaveMax,
                     ]}
-                    min={sampleWaveMin}
-                    max={sampleWaveMax}
+                    min={absorbanceWaveMin}
+                    max={absorbanceWaveMax}
                     onChange={handleSliderChange}
                     aria-labelledby="input-slider"
                   />
@@ -200,8 +199,8 @@ export default function FindPeaks() {
                     onBlur={checkWaveNumRange}
                     InputProps={{
                       inputProps: {
-                        min: absorbWaveMin,
-                        max: absorbWaveMax,
+                        min: absorbanceWaveMin,
+                        max: absorbanceWaveMax,
                       },
                     }}
                   />

--- a/src/routes/FindPeaks.jsx
+++ b/src/routes/FindPeaks.jsx
@@ -36,10 +36,15 @@ export default function FindPeaks() {
   const { error, errorText } = useSelector((store) => store.error);
 
   const [threshold, setThreshold] = useState(0.01);
-  const [lowerBound, setLowerBound] = useState(sampleWaveMin);
-  const [upperBound, setUpperBound] = useState(sampleWaveMax);
+  const [lowerBound, setLowerBound] = useState(
+    sampleWaveMin ? sampleWaveMin : ""
+  );
+  const [upperBound, setUpperBound] = useState(
+    sampleWaveMax ? sampleWaveMax : ""
+  );
   const [dataPoints, setDataPoints] = useState();
   const [tooManyPoints, setTooManyPoints] = useState(true);
+  const [emptyInput, setEmptyInput] = useState(true);
 
   const checkThresholdRange = () => {
     if (threshold < 0.01) {
@@ -93,6 +98,12 @@ export default function FindPeaks() {
 
       setDataPoints(absorbanceData.x.slice(startIndex, endIndex + 1).length);
 
+      if (!lowerBound || !upperBound) {
+        setEmptyInput(true);
+      } else {
+        setEmptyInput(false);
+      }
+
       if (dataPoints > 25000) {
         setTooManyPoints(true);
       } else {
@@ -111,8 +122,6 @@ export default function FindPeaks() {
     sampleWaveMin,
     sampleWaveMax,
   ]);
-
-  console.log(absorbanceData);
 
   if (absorbanceData) {
     return (
@@ -234,6 +243,12 @@ export default function FindPeaks() {
                   Current Number of Data Points Selected: <b>{dataPoints}</b>
                 </p>
 
+                {emptyInput && (
+                  <p>
+                    <b>Please enter data into the empty input field(s)!</b>
+                  </p>
+                )}
+
                 {tooManyPoints && (
                   <p>
                     <b>
@@ -256,7 +271,7 @@ export default function FindPeaks() {
                   fetchURL={FIND_PEAKS}
                   buttonText={"Find Peaks"}
                   buttonStyle={"button"}
-                  tooManyPoints={tooManyPoints}
+                  tooManyPoints={tooManyPoints || emptyInput}
                 />
               </div>
             </div>

--- a/src/style/routes/FindPeaks.css
+++ b/src/style/routes/FindPeaks.css
@@ -89,7 +89,7 @@
 }
 
 #find-peaks-text {
-  padding: 0.5rem 1rem;
+  padding: 5px 0 0 10px;
 }
 
 #find-peaks-data-container {


### PR DESCRIPTION
resolve #369 
Added final fixes for major devtool warnings

resolve #413 
updated `Find Peaks` to fill lower and upper bounds on load properly. This was accomplished by adding a catch for empty inputs
