### PR TITLE
update transmittance plot y-axis label

### DIFF
--- a/src/components/TransmittancePlotly.jsx
+++ b/src/components/TransmittancePlotly.jsx
@@ -63,7 +63,7 @@ export const TransmittancePlotly = forwardRef((props, ref) => {
               yaxis: {
                 autorange: true,
                 title: {
-                  text: "% Transmittance",
+                  text: "Transmittance",
                 },
                 type: "linear",
                 fixedrange: false,


### PR DESCRIPTION
It occurred to me that the vertical axis in the Transmittance spectra should actually be labelled "Transmittance" and not "% Transmittance"